### PR TITLE
Kaboomafoo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ vendor
 phpunit.xml
 build
 composer.lock
+.phpunit.result.cache

--- a/Kaboom.php
+++ b/Kaboom.php
@@ -18,4 +18,14 @@ class Kaboom
 
         throw new KaboomException($message);
     }
+
+    public function todo(string $message, string $date): bool {
+        $timestamp = strtotime($date);
+
+        if (time() < $timestamp) {
+            return false;
+        }
+
+        throw new KaboomException($message);
+    }
 }

--- a/Kaboom.php
+++ b/Kaboom.php
@@ -2,9 +2,14 @@
 
 namespace Beryllium\Kaboom;
 
+/**
+ * Enables force feedback in your code. In a manner of speaking.
+ */
 class Kaboom
 {
     /**
+     * Throw an exception when a custom condition is tripped
+     *
      * @param string   $message
      * @param callable $condition
      *
@@ -19,6 +24,15 @@ class Kaboom
         throw new KaboomException($message);
     }
 
+    /**
+     * Throw an exception once the provided $date has been passed
+     *
+     * @param string $message   The message to embed in the exception
+     * @param string $date      A date string compatible with strftime()
+     *
+     * @return bool
+     * @throws KaboomException
+     */
     public function todo(string $message, string $date): bool {
         $timestamp = strtotime($date);
 

--- a/Kaboom.php
+++ b/Kaboom.php
@@ -4,15 +4,18 @@ namespace Beryllium\Kaboom;
 
 class Kaboom
 {
-    public function __construct($env = null)
-    {
-        if (strtolower($env) == 'dev' && error_reporting() != -1) {
-            return $this->kaboom();
+    /**
+     * @param string   $message
+     * @param callable $condition
+     *
+     * @return bool
+     * @throws KaboomException
+     */
+    public function custom(string $message, callable $condition): bool {
+        if (!$condition()) {
+            return false;
         }
-    }
 
-    public function kaboom()
-    {
-        throw new KaboomException();
+        throw new KaboomException($message);
     }
 }

--- a/README.md
+++ b/README.md
@@ -12,10 +12,43 @@ License: MIT
 
 Inspiration: A twitter joke.
 
-"Here's a useful library: One that detects whether or not you're in a dev environment and explodes if error reporting isn't -1 :-)"
+> "Here's a useful library: One that detects whether or not you're in a dev environment and explodes if error reporting isn't -1 :-)"
 
 https://twitter.com/JeremyKendall/status/420672420253822976
 
 ---
 
-Needless to say, it's not really useful. :)
+And redeveloped as part of a second twitter joke:
+
+> "Here's a fun idea: Temporal Todos ..."
+
+https://twitter.com/Beryllium9/status/1314780273398013952
+
+> A code comment declares an urgent TODO task. Subsequently, an if statement uses the current unix timestamp (as of when it was coded) plus 1 day (in seconds) to detect if a RuntimeException should be thrown to enforce the TODO.
+
+---
+
+## How to use Kaboom
+
+In its default configuration, Kaboom will "blow up", by throwing an exception, if the requirements are tripped.
+
+Here, we set a Todo that will "blow up" starting on October 20th, 2020.
+
+```php
+$kaboom = new Kaboom();
+$kaboom->todo(
+    "Fix this code or you'll be sorry! KAB-200",
+    "2020-10-20"
+);
+```
+
+Alternatively, we can harken back to the original Kaboom implementation and "blow up" if error reporting is insufficient for our environment.
+
+```php
+$env = 'dev';
+$kaboom = new Kaboom();
+$kaboom->custom(
+    "Error reporting is not set correctly!",
+    fn() => strtolower($env) == 'dev' && error_reporting() != -1
+);
+```

--- a/README.md
+++ b/README.md
@@ -49,6 +49,6 @@ $env = 'dev';
 $kaboom = new Kaboom();
 $kaboom->custom(
     "Error reporting is not set correctly!",
-    fn() => strtolower($env) == 'dev' && error_reporting() != -1
+    fn() => strtolower($env) === 'dev' && error_reporting() !== -1
 );
 ```

--- a/Tests/KaboomTest.php
+++ b/Tests/KaboomTest.php
@@ -34,4 +34,25 @@ class KaboomTest extends TestCase
 
         $this->assertFalse($actual, "test passed - exception was not thrown");
     }
+
+    public function testKaboomTodoTrips(): void {
+        $this->expectException(KaboomException::class);
+        $kaboom = new Kaboom();
+
+        $kaboom->todo(
+            "This todo needs to be fixed before Thanksgiving! KAB-201",
+            "2020-10-05"
+        );
+    }
+
+    public function testKaboomTodoDoesNotTrip(): void {
+        $kaboom = new Kaboom();
+
+        $actual = $kaboom->todo(
+            "This todo can be postponed indefinitely. No ticket assigned.",
+            "+2 Days"
+        );
+
+        $this->assertFalse($actual, "test passed - exception was not thrown");
+    }
 }

--- a/Tests/KaboomTest.php
+++ b/Tests/KaboomTest.php
@@ -8,25 +8,30 @@ use PHPUnit\Framework\TestCase;
 
 class KaboomTest extends TestCase
 {
-    public function testKaboomGoesKaboom()
+    public function testCustomKaboomWhenConditionTrips(): void
     {
         $this->expectException(KaboomException::class);
+        $kaboom = new Kaboom();
+
         error_reporting(E_ALL);
-        $kaboom = new Kaboom('prod');
-        $kaboom->kaboom();
+        $env = 'dev';
+        $kaboom->custom(
+            'Environment check failed!',
+            fn() => strtolower($env) === 'dev' && error_reporting() !== -1
+        );
     }
 
-    public function testConstructorGoesKaboomWhenDevErrorReportingChosenPoorly()
+    public function testCustomKaboomWhenConditionFails(): void
     {
-        $this->expectException(KaboomException::class);
-        error_reporting(E_ALL);
-        $kaboom = new Kaboom('dev');
-    }
+        $kaboom = new Kaboom();
 
-    public function testConstructorDoesNotKaboomWhenDevErrorReportingChosenWisely()
-    {
         error_reporting(-1);
-        $kaboom = new Kaboom('dev');
-        $this->assertTrue(true, "test passed - exception was not thrown");
+        $env = 'dev';
+        $actual = $kaboom->custom(
+            'Environment check failed!',
+            fn() => strtolower($env) === 'dev' && error_reporting() !== -1
+        );
+
+        $this->assertFalse($actual, "test passed - exception was not thrown");
     }
 }

--- a/Tests/KaboomTest.php
+++ b/Tests/KaboomTest.php
@@ -3,12 +3,14 @@
 namespace Beryllium\Kaboom\Tests;
 
 use Beryllium\Kaboom\Kaboom;
+use Beryllium\Kaboom\KaboomException;
+use PHPUnit\Framework\TestCase;
 
-class KaboomTest extends \PHPUnit_Framework_TestCase
+class KaboomTest extends TestCase
 {
     public function testKaboomGoesKaboom()
     {
-        $this->setExpectedException('Beryllium\Kaboom\KaboomException');
+        $this->expectException(KaboomException::class);
         error_reporting(E_ALL);
         $kaboom = new Kaboom('prod');
         $kaboom->kaboom();
@@ -16,7 +18,7 @@ class KaboomTest extends \PHPUnit_Framework_TestCase
 
     public function testConstructorGoesKaboomWhenDevErrorReportingChosenPoorly()
     {
-        $this->setExpectedException('Beryllium\Kaboom\KaboomException');
+        $this->expectException(KaboomException::class);
         error_reporting(E_ALL);
         $kaboom = new Kaboom('dev');
     }
@@ -25,5 +27,6 @@ class KaboomTest extends \PHPUnit_Framework_TestCase
     {
         error_reporting(-1);
         $kaboom = new Kaboom('dev');
+        $this->assertTrue(true, "test passed - exception was not thrown");
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,12 +8,11 @@
             "email": "kevin.boyd@gmail.com"
         }
     ],
-    "minimum-stability": "dev",
     "require": {
-        "phpunit/phpunit": "3.*"
+        "php": ">=7.4",
+        "phpunit/phpunit": "9.*"
     },
     "autoload": {
-        "psr-0": { "Beryllium\\Kaboom\\": "" }
-    },
-    "target-dir": "Beryllium/Kaboom"
+        "psr-4": { "Beryllium\\Kaboom\\": "" }
+    }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,21 +7,11 @@
     convertWarningsToExceptions="true"
     processIsolation="false"
     stopOnFailure="false"
-    syntaxCheck="false"
     bootstrap="vendor/autoload.php">
+
     <testsuites>
         <testsuite name="Kaboom Test Suite">
-            <directory>./Tests/</directory>
+            <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory>./</directory>
-            <exclude>
-                <directory>./vendor</directory>
-                <directory>./Tests</directory>
-            </exclude>
-        </whitelist>
-    </filter>
 </phpunit>


### PR DESCRIPTION
This PR modifies the original Kaboom library to support custom conditions as well as "todo" conditions that use a date string.

In its default configuration, Kaboom will "blow up", by throwing an exception, if the requirements are tripped.

Here, we set a Todo that will "blow up" starting on October 20th, 2020.

```php
$kaboom = new Kaboom();
$kaboom->todo(
    "Fix this code or you'll be sorry! KAB-200",
    "2020-10-20"
);
```

Alternatively, we can harken back to the original Kaboom implementation and "blow up" if error reporting is insufficient for our environment.

```php
$env = 'dev';
$kaboom = new Kaboom();
$kaboom->custom(
    "Error reporting is not set correctly!",
    fn() => strtolower($env) === 'dev' && error_reporting() !== -1
);
```