### PR TITLE
Rewrite the entire implementation of Kaboom

### DIFF
--- a/Handlers/ExceptionHandler.php
+++ b/Handlers/ExceptionHandler.php
@@ -4,9 +4,13 @@ namespace Beryllium\Kaboom\Handlers;
 
 use Beryllium\Kaboom\KaboomException;
 
+/**
+ * The Earth-Shattering Kaboom you've been looking for!
+ */
 class ExceptionHandler implements HandlerInterface
 {
-    public function handle(string $message): bool {
+    public function handle(string $message): void
+    {
         throw new KaboomException($message);
     }
 }

--- a/Handlers/GroupHandler.php
+++ b/Handlers/GroupHandler.php
@@ -2,6 +2,12 @@
 
 namespace Beryllium\Kaboom\Handlers;
 
+/**
+ * GroupHandler allows you to declare multiple handlers for messages.
+ *
+ * They will be invoked in order of declaration,
+ * so make sure to put any code-terminating ones at the end.
+ */
 class GroupHandler implements HandlerInterface
 {
     protected array $handlers;
@@ -18,7 +24,8 @@ class GroupHandler implements HandlerInterface
         }
     }
 
-    public function handle(string $message) {
+    public function handle(string $message): void
+    {
         foreach ($this->handlers as $handler) {
             $handler->handle($message);
         }

--- a/Handlers/HandlerInterface.php
+++ b/Handlers/HandlerInterface.php
@@ -4,5 +4,5 @@ namespace Beryllium\Kaboom\Handlers;
 
 interface HandlerInterface
 {
-    public function handle(string $message);
+    public function handle(string $message): void;
 }

--- a/Handlers/LoggingHandler.php
+++ b/Handlers/LoggingHandler.php
@@ -6,6 +6,12 @@ use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 
+/**
+ * Kaboom's LoggingHandler
+ *
+ * It may not deliver an earth-shattering Kaboom,
+ * but it should help you log & respond to Kaboom messages.
+ */
 class LoggingHandler implements HandlerInterface, LoggerAwareInterface
 {
     protected LoggerInterface $logger;
@@ -16,7 +22,8 @@ class LoggingHandler implements HandlerInterface, LoggerAwareInterface
         $this->setLogger($logger)->setLoggerLevel($level);
     }
 
-    public function handle(string $message) {
+    public function handle(string $message): void
+    {
         $this->logger->{$this->level}($message);
     }
 
@@ -29,7 +36,7 @@ class LoggingHandler implements HandlerInterface, LoggerAwareInterface
 
     private function setLoggerLevel(string $level): self
     {
-        $levels = [
+        $this->level = match ($level) {
             LogLevel::EMERGENCY,
             LogLevel::ALERT,
             LogLevel::CRITICAL,
@@ -37,14 +44,9 @@ class LoggingHandler implements HandlerInterface, LoggerAwareInterface
             LogLevel::WARNING,
             LogLevel::NOTICE,
             LogLevel::INFO,
-            LogLevel::DEBUG,
-        ];
-
-        if (!in_array($level, $levels, true)) {
-            $level = LogLevel::WARNING;
-        }
-
-        $this->level = $level;
+            LogLevel::DEBUG => $level,
+            default => LogLevel::WARNING
+        };
 
         return $this;
     }

--- a/Handlers/NullHandler.php
+++ b/Handlers/NullHandler.php
@@ -2,8 +2,10 @@
 
 namespace Beryllium\Kaboom\Handlers;
 
+/**
+ * A Null Handler for Kaboom. Eats messages for breakfast.
+ */
 class NullHandler implements HandlerInterface
 {
-    public function handle(string $message) {
-    }
+    public function handle(string $message): void {}
 }

--- a/Kaboom.php
+++ b/Kaboom.php
@@ -6,7 +6,13 @@ use Beryllium\Kaboom\Handlers\ExceptionHandler;
 use Beryllium\Kaboom\Handlers\HandlerInterface;
 
 /**
- * Enables force feedback in your code. In a manner of speaking.
+ * Emits messages or runs code based on provided conditions.
+ *
+ * Message behaviour is configured using Handlers.
+ *
+ * For a gentle approach, the LoggingHandler will send the message to your logging system.
+ *
+ * If not specified, Kaboom uses an ExceptionHandler that emits exceptions.
  */
 class Kaboom
 {
@@ -18,42 +24,72 @@ class Kaboom
     }
 
     /**
-     * Throw an exception when a custom condition is tripped
+     * Executes the specified wrapped code when the callable condition is tripped
      *
-     * @param string   $message
-     * @param callable $condition
+     * If `$execute()` returns a string, the output will be sent to the Handler. For example,
+     * if a failure occurs, the returned string would cause Kaboom to Log or throw an Exception.
+     *
+     * Otherwise, true is returned to signify that the wrapped code was executed, or false is returned
+     * to indicate that the condition did not trip.
+     *
+     * Exampole:
+     *
+     *   Kaboom Exception when the current environment is Dev but error reporting is not configured
+     *   to report all errors:
+     *
+     *      $kaboom = new Kaboom(); // Exception handler is configured by default
+     *      $kaboom->condition(
+     *          fn () => getenv('ENV') === 'dev' && error_reporting() !== -1,
+     *          fn () => 'Error reporting should be enabled for ALL ERRORS in dev mode!'
+     *      );
+     *
+     * @param callable $condition   A callable that returns true or false, to determine whether to execute
+     * @param callable $execute     When $condition() returns true, this code is executed
      *
      * @return bool
-     * @throws KaboomException
+     * @throws KaboomException      Depending on the configured Handler
      */
-    public function custom(string $message, callable $condition): bool {
+    public function condition(callable $condition, callable $execute): bool
+    {
         if (!$condition()) {
             return false;
         }
 
-        $this->handler->handle($message);
+        $output = $execute();
+
+        // Wrapped code that returns a string shall be sent to the Handler.
+        if (is_string($output)) {
+            $this->handler->handle($output);
+        }
 
         return true;
     }
 
     /**
-     * Throw an exception once the provided $date has been passed
+     * Trip a condition after the provided $date has passed
      *
-     * @param string $message   The message to embed in the exception
-     * @param string $date      A date string compatible with strftime()
+     * @param string $date      A date string compatible with strtotime()
+     * @param string $message   The message to embed in the condition result
      *
      * @return bool
-     * @throws KaboomException
+     * @throws KaboomException  Depending on the configured Handler
      */
-    public function todo(string $message, string $date): bool {
-        $timestamp = strtotime($date);
+    public function afterMessage(string $date, string $message): bool
+    {
+        return $this->condition(fn () => time() > strtotime($date), fn () => $message);
+    }
 
-        if (time() < $timestamp) {
-            return false;
-        }
-
-        $this->handler->handle($message);
-
-        return true;
+    /**
+     * Trip a condition before the provided $date has passed
+     *
+     * @param string $date      A date string compatible with strtotime()
+     * @param string $message   The message to embed in the condition result
+     *
+     * @return bool
+     * @throws KaboomException  Depending on the configured Handler
+     */
+    public function beforeMessage(string $date, string $message): bool
+    {
+        return $this->condition(fn () => time() < strtotime($date), fn () => $message);
     }
 }

--- a/KaboomException.php
+++ b/KaboomException.php
@@ -2,6 +2,6 @@
 
 namespace Beryllium\Kaboom;
 
-class KaboomException extends \Exception
+class KaboomException extends \RuntimeException
 {
 }

--- a/README.md
+++ b/README.md
@@ -10,115 +10,203 @@ Contributors:
 
 License: MIT
 
-Inspiration: A twitter joke.
+## What Is Kaboom?
 
-> "Here's a useful library: One that detects whether or not you're in a dev environment and explodes if error reporting isn't -1 :-)"
+Kaboom helps you deal with the realities of coding in long-term projects.
+
+It provides an interface for adding temporary code to projects, code that needs
+to either start or stop running after a predetermined date on the calendar, or
+safety protections based on environment conditions.
+
+### ... okay then, WHY Is Kaboom?
+
+In my career, I've encountered a number of scenarios that Kaboom can help with,
+but the main one always seems to be forgetfulness. Organizations often don't
+take the time to circle back and clean things up, unless it is specifically
+called out in some way. It's often left up to individuals to remember to return
+to some arbitrary old project and spruce it up.
+
+By adding Kaboom-backed tripwires to your project, you can schedule future
+reminders that are emitted by the code itself - directly into your logging and
+reporting systems!
+
+You can also customize the tripwire behaviour. Maybe instead of logging after a
+set calendar date, you would prefer to detect an environment condition and throw
+an exception. This was the original use case for Kaboom, inspired by a joke on
+an ancient social media website called 'Twitter' from developer Jeremy Kendall.
+
+> "Here's a useful library: One that detects whether or not you're in a dev
+> environment and explodes if error reporting isn't -1 :-)"
 
 https://twitter.com/JeremyKendall/status/420672420253822976
 
 ---
 
-And redeveloped as part of a second twitter joke:
+After a while, another idea arose:
 
 > "Here's a fun idea: Temporal Todos ..."
 
 https://twitter.com/Beryllium9/status/1314780273398013952
 
-> A code comment declares an urgent TODO task. Subsequently, an if statement uses the current unix timestamp (as of when it was coded) plus 1 day (in seconds) to detect if a RuntimeException should be thrown to enforce the TODO.
+> A code comment declares an urgent TODO task. Subsequently, an if statement
+> uses the current unix timestamp (as of when it was coded) plus 1 day (in
+> seconds) to detect if a RuntimeException should be thrown to enforce the TODO.
 
 ---
 
+And then I thought, why not fold that functionality into Kaboom, and use it to
+help codebases fight back against cruft?
+
 ## How to use Kaboom
 
-In its default configuration, Kaboom will "blow up", by throwing an exception, if the requirements are tripped.
+Kaboom's default behaviour is to throw a KaboomException if conditions are met.
 
-Here, we set a Todo that will "blow up" starting on October 20th, 2020.
+This is because the `ExceptionHandler` class is used in the default constructor.
+
+**`ExceptionHandler` - Example 1:**
+
+Here, we set a message that will "go kaboom" starting on Oct 20, 2020.
 
 ```php
 $kaboom = new Kaboom();
-$kaboom->todo(
-    "Fix this code or you'll be sorry! KAB-200",
-    "2020-10-31"
+$kaboom->afterMessage(
+    "2020-10-20",
+    "Fix this code or you'll be sorry! KAB-200"
 );
 ```
 
-Alternatively, we can harken back to the original Kaboom implementation and "blow up" if error reporting is insufficient for our environment.
+**`ExceptionHandler` - Example 2:**
+
+Alternatively, we can harken back to the original Kaboom inspiration and
+"go kaboom" if error reporting is insufficient for our environment.
 
 ```php
 $env = 'dev';
 $kaboom = new Kaboom();
-$kaboom->custom(
-    "Error reporting is not set correctly!",
-    fn() => strtolower($env) === 'dev' && error_reporting() !== -1
+$kaboom->condition(
+    fn () => strtolower($env) === 'dev' && error_reporting() !== -1,
+    fn () => "Error reporting is not set correctly!",
 );
 ```
 
-## Configuring a Custom Kaboom Behaviour
+### Configuring a Custom Kaboom Handler
 
-Kaboom supports various Handlers that control how it behaves when a condition is tripped.
+Kaboom supports various Handlers that control how it behaves when a condition is
+tripped.
 
-### Logging
+#### LoggingHandler
+
+**`LoggingHandler` - Example 3:**
 
 To configure Kaboom to log instead of throwing an exception, do this:
 
 ```php
-$kaboom = new Beryllium\Kaboom\Kaboom(new Beryllium\Kaboom\Handlers\LoggingHandler($logger));
-$kaboom->todo(
-    "Fix this code or you'll be sorry! KAB-200",
-    "2020-10-31"
+use Beryllium\Kaboom\Kaboom;
+use Beryllium\Kaboom\Handlers\LoggingHandler;
+use Psr\Log\LogLevel;
+
+$kaboom = new Kaboom(
+    new LoggingHandler($logger, LogLevel::ERROR)
+);
+
+$kaboom->afterMessage(
+    "2020-10-31",
+    "Fix this code or you'll be sorry! KAB-200"
 );
 ```
 
-This can get a little lengthy, which is where a Dependency Injection Container would help.
+This can get a little lengthy, which is where a Dependency Injection Container
+would help.
 
-For example, you could configure `LoggingHandler` to be the default implementation of `HandlerInterface`, which would
-then allow autowiring to wire things together so all you would have to request is
+For example, you could configure `LoggingHandler` to be the default
+implementation of `HandlerInterface`, which would then allow autowiring to wire
+things together so all you would have to request is
 `$container->get(Beryllium\Kaboom\Kaboom::class)`.
 
-### Null
+**NOTE:** The second parameter of `LoggingHandler`, the Log Level, is optional.
+          The default log level is `WARNING`.
 
-You may want to have different configurations for different environments, such as not wanting to blow up on Production.
+#### Null Handler
+
+**`NullHandler` - Example 4:**
+
+You may want to have different configurations for different environments, such
+as not wanting to blow up on Production.
 
 In that case, you can use the Null handler:
 
 ```php
-$kaboom = new Beryllium\Kaboom\Kaboom(
-    $env === 'prod' ? new Beryllium\Kaboom\Handlers\NullHandler() : new Beryllium\Kaboom\Handlers\ExceptionHandler()
+use Beryllium\Kaboom\Kaboom;
+use Beryllium\Kaboom\Handlers\NullHandler;
+use Beryllium\Kaboom\Handlers\ExceptionHandler;
+
+$kaboom = new Kaboom(
+    $env === 'prod' ? new NullHandler() : new ExceptionHandler()
 );
 
-$kaboom->todo(
-    "Fix this code or you'll be sorry! KAB-200",
-    "2020-10-31"
+$kaboom->afterMessage(
+    "2020-10-31",
+    "Fix this code or you'll be sorry! KAB-200"
 );
 ```
 
-### Grouped
+#### Grouped
 
-Perhaps you want to have multiple handlers, such as if you've written a custom Slack handler (please contribute it back
-if so!! thanks!!). That's where the `GroupHandler` comes in.
+Perhaps you want to have multiple handlers, such as if you've written a custom
+Slack handler (please contribute it back if so!! thanks!!). That's where the
+`GroupHandler` comes in.
+
+**`GroupHandler` - Example 5:**
 
 ```php
-$kaboom = new Beryllium\Kaboom\Kaboom(
-    new Beryllium\Kaboom\Handlers\GroupHandler([
-        new Beryllium\Kaboom\Handlers\LoggingHandler(),
-        new Your\Custom\Namespace\SlackHandler(),
+use Beryllium\Kaboom\Kaboom;
+use Beryllium\Kaboom\Handlers\GroupHandler;
+use Beryllium\Kaboom\Handlers\LoggingHandler;
+use Your\Custom\Namespace\SlackHandler;
+
+$kaboom = new Kaboom(
+    new GroupHandler([
+        new LoggingHandler(),
+        new SlackHandler(),
     ])
 );
 
-$kaboom->todo(
-    "Fix this code or you'll be sorry! KAB-200",
-    "2020-10-31"
+$kaboom->afterMessage(
+    "2020-10-31",
+    "Fix this code or you'll be sorry! KAB-200"
 );
 ```
 
-Now, Kaboom will loop through your provided handlers and log the message and then send it to Slack (in that order).
+Now, Kaboom will loop through your provided handlers and log the message and
+then send it to Slack (in that order).
+
+## ... But Why?
+
+You might look at the implementation and think, well, this is just an `if`
+condition. And yeah, you're right - but it's a tiny bit more than that.
+
+Kaboom establishes intentionality. When you use it to wrap something, you're
+making a statement. You're saying that this `if` condition is special.
+
+Maybe you're saying that the code is temporary and can be deleted at some point.
+
+Maybe you're saying that it's an important safety protection, but you want to
+be able to easily control Production vs Development behaviour to minimize user
+impact.
+
+Maybe you just want to have some deeper insight into a particular type of `if`
+condition that is peppered throughout your codebase.
+
+Regardless, this libary is here for your needs - whether you want a helpful log
+entry, or you're just looking for an earth-shattering Kaboom.
 
 ## Contributions Welcome
 
-If you have ideas for making Kaboom more widely useful, please add Issues or PRs.
+If you have ideas for making Kaboom more widely useful, please add Issues or
+PRs.
 
-If you've found Kaboom to be useful in your projects, please let me know on Twitter!
+Have you found Kaboom to be useful in your projects? Let me know on Mastodon!
 
-[@beryllium9](https://twitter.com/beryllium9)
+[@kboyd@phpc.social](https://phpc.social/@kboyd)
 
 Thanks!

--- a/Tests/KaboomTest.php
+++ b/Tests/KaboomTest.php
@@ -19,9 +19,9 @@ class KaboomTest extends TestCase
 
         error_reporting(E_ALL);
         $env = 'dev';
-        $kaboom->custom(
-            'Environment check failed!',
-            fn() => strtolower($env) === 'dev' && error_reporting() !== -1
+        $kaboom->condition(
+            fn () => strtolower($env) === 'dev' && error_reporting() !== -1,
+            fn () => 'Environment check failed!'
         );
     }
 
@@ -31,36 +31,57 @@ class KaboomTest extends TestCase
 
         error_reporting(-1);
         $env = 'dev';
-        $actual = $kaboom->custom(
-            'Environment check failed!',
-            fn() => strtolower($env) === 'dev' && error_reporting() !== -1
+        $actual = $kaboom->condition(
+            fn () => strtolower($env) === 'dev' && error_reporting() !== -1,
+            fn () => 'Environment check failed!'
         );
 
         $this->assertFalse($actual, "test passed - exception was not thrown");
     }
 
-    public function testKaboomTodoTrips(): void {
+    public function testKaboom_AfterMessage_Trips_For_PastDate(): void {
         $this->expectException(KaboomException::class);
         $kaboom = new Kaboom();
 
-        $kaboom->todo(
-            "This todo needs to be fixed before Thanksgiving! KAB-201",
+        $kaboom->afterMessage(
+            "You have one week to fix this before Canadian Thanksgiving! KAB-201",
             "2020-10-05"
         );
     }
 
-    public function testKaboomTodoDoesNotTrip(): void {
+    public function testKaboom_AfterMessage_DoesNotTrip_For_FutureDate(): void {
         $kaboom = new Kaboom();
 
-        $actual = $kaboom->todo(
-            "This todo can be postponed indefinitely. No ticket assigned.",
-            "+2 Days"
+        $actual = $kaboom->afterMessage(
+            "+2 Days",
+            "This todo can be postponed indefinitely. No ticket assigned."
         );
 
         $this->assertFalse($actual, "test passed - exception was not thrown");
     }
 
-    public function testKaboomLoggingHandler(): void {
+    public function testKaboom_BeforeMessage_Trips_For_FutureDate(): void {
+        $this->expectException(KaboomException::class);
+        $kaboom = new Kaboom();
+
+        $kaboom->beforeMessage(
+            "+2 Days",
+            "Alert! Alert! This code should not have been invoked! Related to project KAB-202"
+        );
+    }
+
+    public function testKaboom_BeforeMessage_DoesNotTrip_For_PastDate(): void {
+        $kaboom = new Kaboom();
+
+        $actual = $kaboom->beforeMessage(
+            "-2 Days",
+            "Once the provided date has passed, it becomes okay for this code to have been invoked."
+        );
+
+        $this->assertFalse($actual, "test passed - exception was not thrown");
+    }
+
+    public function testKaboom_LoggingHandler_Receives_Entries(): void {
         $logger = new class extends AbstractLogger {
             public array $logs = [];
 
@@ -70,30 +91,30 @@ class KaboomTest extends TestCase
             }
         };
 
-        $message = "This todo needs to be fixed before Thanksgiving! KAB-201";
+        $message = "You have one week to fix this before Canadian Thanksgiving! KAB-201";
 
         $kaboom = new Kaboom(new LoggingHandler($logger));
-        $kaboom->todo(
-            $message,
-            "2020-10-05"
+        $kaboom->afterMessage(
+            "2020-10-05",
+            $message
         );
 
         $this->assertSame($message, $logger->logs['warning'][0]['message']);
     }
 
-    public function testKaboomNullHandler(): void {
-        $message = "This todo needs to be fixed before Thanksgiving! KAB-201";
+    public function testKaboom_NullHandler_Does_Nothing(): void {
+        $message = "You have one week to fix this before Canadian Thanksgiving! KAB-201";
 
         $kaboom = new Kaboom(new NullHandler());
-        $kaboom->todo(
-            $message,
-            "2020-10-05"
+        $kaboom->afterMessage(
+            "2020-10-05",
+            $message
         );
 
         $this->assertTrue(true, 'nothing happened. good.');
     }
 
-    public function testKaboomGroupHandler(): void {
+    public function testKaboom_GroupHandler_Sends_To_Each_Handler_In_Group(): void {
         $mockLogger = $this->createMock(AbstractLogger::class);
         $mockNull   = $this->createMock(NullHandler::class);
 
@@ -107,12 +128,12 @@ class KaboomTest extends TestCase
             ]
         );
 
-        $message = "This todo needs to be fixed before Thanksgiving! KAB-201";
+        $message = "You have one week to fix this before Canadian Thanksgiving! KAB-201";
 
         $kaboom = new Kaboom($groupHandler);
-        $kaboom->todo(
-            $message,
-            "2020-10-05"
+        $kaboom->afterMessage(
+            "2020-10-05",
+            $message
         );
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": ">=7.4",
+        "php": ">=8.0",
         "psr/log": "^1.1"
     },
     "require-dev": {

--- a/example.php
+++ b/example.php
@@ -1,9 +1,22 @@
 <?php
 
-require_once('Kaboom.php');
+require __DIR__ . '/vendor/autoload.php';
 
 use Beryllium\Kaboom\Kaboom;
 
-$kaboom = new Kaboom('dev');
-echo "Everything is OK.\n";
-$kaboom = new Kaboom('prod');
+$env = 'dev';
+
+$kaboom = new Kaboom();
+$kaboom->condition(
+    fn () => $env === 'prod',
+    fn () => 'This should never run in prod mode!'
+);
+
+echo "\n\nEverything is OK in Dev mode. Switching to Prod mode.\n\n\n";
+
+$env = 'prod';
+$kaboom->condition(
+    fn () => $env === 'prod',
+    fn () => 'This should never run in prod mode!'
+);
+


### PR DESCRIPTION
With this rewrite, the central concept of Kaboom is the `condition` method.

```php
$kaboom = new Beryllium\Kaboom\Kaboom;

$env = 'prod';
$kaboom->condition(
    fn () => $env === 'prod',
    fn () => 'This should never run in prod mode!'
);
```

The first parameter, `callable $condition`, performs the check to determine if action is needed. If action is not needed, `false` is returned.

The second parameter, `callable $execute`, performs the desired action.  If this callable returns a string, then Kaboom activates and passes the string to the handler. Otherwise, it assumes everything is OK and carries on, returning `true` to signal that the code was executed.

For some of the original intended behaviours, helpers `afterMessage` and `beforeMessage` are provided.

To create some code that will begin adding a log entry once a specific date has been passed, such as for helping build reports of code that can be removed, you can use `afterMessage`:

```php
use Beryllium\Kaboom\Kaboom;
use Beryllium\Kaboom\Handlers\LoggingHandler;
use Psr\Log\LogLevel;

$kaboom = new Kaboom(
    new LoggingHandler($logger, LogLevel::ERROR)
);

$kaboom->afterMessage(
    "2020-10-31",
    "Fix this code or you'll be sorry! KAB-200"
);
```